### PR TITLE
Fix crash when localplayer isn't ready quickly enough

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -58,17 +58,20 @@ minetest.register_globalstep(function(dtime)
 	end
 end)
 
-minetest.after(3, function()
+local function find_hud()
 	local player = minetest.localplayer
+	if not player then minetest.after(3,find_hud) end
 	local def
 	local i = -1
 	repeat
 		i = i + 1
-		def = player:hud_get(i)
+		def = player and player:hud_get(i)
 	until not def or def.text == "hbhunger_icon.png"
 	if def then
 		hud_id = i
 	end
-end)
+end
+
+minetest.after(3, find_hud)
 
 minetest.register_cheat("AutoEat", "Player", "autoeat")


### PR DESCRIPTION
Fixes #1

In some situations minetest.localplayer isn't available after 3 seconds. this catches that case and tries again after another 3 seconds until the hud is found.